### PR TITLE
PR4

### DIFF
--- a/src/main/java/com/inditex/pricing/ecommercepricingapi/domain/model/ErrorResponse.java
+++ b/src/main/java/com/inditex/pricing/ecommercepricingapi/domain/model/ErrorResponse.java
@@ -1,10 +1,15 @@
 package com.inditex.pricing.ecommercepricingapi.domain.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 /**
  * DTO utilizado para devolver los errores de forma consistente.
  */
-public record ErrorResponse(String code, String message, List<String> details) {
+@Schema(description = "Estructura de la respuesta de error")
+public record ErrorResponse(
+    @Schema(description = "Código HTTP del error") String code,
+    @Schema(description = "Mensaje resumido del error") String message,
+    @Schema(description = "Listado de detalles adicionales") List<String> details) {
 }
 

--- a/src/main/java/com/inditex/pricing/ecommercepricingapi/infrastructure/adapter/input/rest/PriceRestAdapter.java
+++ b/src/main/java/com/inditex/pricing/ecommercepricingapi/infrastructure/adapter/input/rest/PriceRestAdapter.java
@@ -13,7 +13,11 @@ import com.inditex.pricing.ecommercepricingapi.domain.model.Price;
 import com.inditex.pricing.ecommercepricingapi.infrastructure.adapter.input.rest.model.PriceResponse;
 import com.inditex.pricing.ecommercepricingapi.infrastructure.adapter.input.rest.mapper.PriceResponseMapper;
 import com.inditex.pricing.ecommercepricingapi.infrastructure.adapter.input.rest.validation.ValidDateTime;
+import com.inditex.pricing.ecommercepricingapi.domain.model.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.NotNull;
@@ -55,10 +59,15 @@ public class PriceRestAdapter {
    */
   @GetMapping(params = PARAM_APPLICATION_DATE)
   @Operation(summary = "Obtiene el precio aplicable a una fecha")
-  @ApiResponses({@ApiResponse(responseCode = "200", description = "Precio encontrado"),
-      @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
-      @ApiResponse(responseCode = "404", description = "Precio no encontrado"),
-      @ApiResponse(responseCode = "500", description = "Error interno del servidor")})
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "Precio encontrado",
+          content = @Content(schema = @Schema(implementation = PriceResponse.class))),
+      @ApiResponse(responseCode = "400", description = "Solicitud inválida",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "Precio no encontrado",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "Error interno del servidor",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))})
   public EntityModel<PriceResponse> getPrice(
       @PathVariable @Positive(message = VAL_BRAND_ID_POSITIVE) Long brandId,
       @PathVariable @Positive(message = VAL_PRODUCT_ID_POSITIVE) Long productId,
@@ -87,10 +96,15 @@ public class PriceRestAdapter {
    */
   @GetMapping
   @Operation(summary = "Lista los precios disponibles para un producto")
-  @ApiResponses({@ApiResponse(responseCode = "200", description = "Precios encontrados"),
-      @ApiResponse(responseCode = "404", description = "Precios no encontrados"),
-      @ApiResponse(responseCode = "400", description = "Solicitud inválida"),
-      @ApiResponse(responseCode = "500", description = "Error interno del servidor")})
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "Precios encontrados",
+          content = @Content(array = @ArraySchema(schema = @Schema(implementation = PriceResponse.class)))),
+      @ApiResponse(responseCode = "404", description = "Precios no encontrados",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "400", description = "Solicitud inválida",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "Error interno del servidor",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))})
   public CollectionModel<PriceResponse> getPrices(
       @PathVariable @Positive(message = VAL_BRAND_ID_POSITIVE) Long brandId,
       @PathVariable @Positive(message = VAL_PRODUCT_ID_POSITIVE) Long productId) {

--- a/src/main/java/com/inditex/pricing/ecommercepricingapi/infrastructure/adapter/input/rest/model/PriceResponse.java
+++ b/src/main/java/com/inditex/pricing/ecommercepricingapi/infrastructure/adapter/input/rest/model/PriceResponse.java
@@ -1,5 +1,6 @@
 package com.inditex.pricing.ecommercepricingapi.infrastructure.adapter.input.rest.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -7,9 +8,11 @@ import java.time.LocalDateTime;
 /**
  * DTO expuesto por la API REST.
  */
-public record PriceResponse(Long productId,
-                            Long brandId,
-                            LocalDateTime startDate,
-                            LocalDateTime endDate,
-                            BigDecimal price) {
+@Schema(description = "Datos de precio devueltos por la API")
+public record PriceResponse(
+    @Schema(description = "Identificador del producto") Long productId,
+    @Schema(description = "Identificador de la marca") Long brandId,
+    @Schema(description = "Fecha de inicio de aplicación") LocalDateTime startDate,
+    @Schema(description = "Fecha fin de aplicación") LocalDateTime endDate,
+    @Schema(description = "Precio aplicado") BigDecimal price) {
 }


### PR DESCRIPTION
## Summary
- annotate `ErrorResponse` and `PriceResponse` with OpenAPI schema descriptions
- document response bodies for price endpoints using `@ApiResponse`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684fcd909e2c8327a091acae10b34671